### PR TITLE
Pillow库新版本中getsize方法弃用导致无法正常返回图片

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# 默认忽略的文件
+/shelf/
+/workspace.xml
+# 基于编辑器的 HTTP 客户端请求
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="zombie.Zombie.*" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.12 (nonebot_plugin_bfinfo) (2)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (nonebot_plugin_bfinfo) (2)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/nonebot_plugin_bfinfo.iml" filepath="$PROJECT_DIR$/.idea/nonebot_plugin_bfinfo.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/nonebot_plugin_bfinfo.iml
+++ b/.idea/nonebot_plugin_bfinfo.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.venv" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/nonebot_plugin_bfinfo/__init__.py
+++ b/nonebot_plugin_bfinfo/__init__.py
@@ -59,7 +59,6 @@ def get_data(player_name, bfversion):
     global get_json
     if bfversion == "bf1":
         url = f"https://api.gametools.network/bf1/all/?name={player_name}&lang=en-us"
-        print ( url )
     elif bfversion == "bfv":
         url = f"https://api.gametools.network/bfv/all/?name={player_name}&lang=en-us"
     get_data = requests.get ( url )
@@ -366,11 +365,15 @@ async def getBFI(bot: Bot, event: Event, state: T_State):
         await BFIS.finish ( "战绩查询+游戏ID" )
     get_data ( msg, "bf1" )  # 保存图片给本地路径
     # ID不存在抛出异常
-    draw_img ( "bf1" )
-    # img="src/plugins/BF1_record/record.png"
-    await BFIS.send ( Message ( '详细数据访问:' + 'https://battlefieldtracker.com/bf1/profile/pc/' + f'{msg}' ) )
-    await BFIS.send ( send_img ( "record.png" ) )
-    # pathlib.Path('file_path').as_uri()
+    try:
+        draw_img ( "bf1" )
+        # img="src/plugins/BF1_record/record.png"
+        await BFIS.send ( Message ( '详细数据访问:' + 'https://battlefieldtracker.com/bf1/profile/pc/' + f'{msg}' ) )
+        await BFIS.send ( send_img ( "record.png" ) )
+        # pathlib.Path('file_path').as_uri()
+    except Exception as e:
+        await BFIS.send ( Message ( '玩家ID不存在' ) )
+        raise e
 
 
 @BFVS.handle ()


### PR DESCRIPTION
参考博客：https://blog.csdn.net/a1397852386/article/details/134475080?ops_request_misc=&request_id=&biz_id=102&utm_term=FreeSizeFont%E6%B2%A1%E6%9C%89getsize%E7%94%A8%E6%B3%95&utm_medium=distribute.pc_search_result.none-task-blog-2~all~sobaiduweb~default-0-134475080.142^v100^pc_search_result_base6&spm=1018.2226.3001.4187

有一些细小问题我还未修改：比如应该使用aiohttp库发送异步请求替代requests库，避免发生主线程阻塞（requests 库是一个同步的 HTTP 客户端库。当你在异步代码中使用 requests 发起 HTTP 请求时，整个线程会等待请求完成，导致主线程阻塞。这会破坏异步代码的并发性，尤其是在 Nonebot 等基于 asyncio 的异步框架中）